### PR TITLE
made logout cookie destroy into a redirect function instead of both b…

### DIFF
--- a/controllers/frontEndRoutes.js
+++ b/controllers/frontEndRoutes.js
@@ -205,8 +205,9 @@ router.get('/sell', async (req, res) => {
 })
 
 router.get('/logout', (req, res) => {
-    req.session.destroy()
-    res.redirect('/')
+    req.session.destroy(()=>{
+        res.redirect('/')
+    })
 })
 
 router.get('*', (req, res) => {


### PR DESCRIPTION
…eing run at same time sometimes causing redirect to finish ahead of destroy leaving username on homepage until manual refresh